### PR TITLE
Warning on Python 3.12+

### DIFF
--- a/printnodeapi/auth.py
+++ b/printnodeapi/auth.py
@@ -119,7 +119,7 @@ class Auth:
             raise Exception('status code: ' + str(response.status_code))
 
     def _is_hundreth(self, hundreth, number):
-        pattern = str(hundreth) + '\d{2,}'
+        pattern = str(hundreth) + r'\d{2,}'
         return bool(re.match(pattern, str(number)))
 
     def _fix_unicode(self, json_object):


### PR DESCRIPTION
convert str to raw str for escape sequence passed to regex.

Original code works but throws a warning in Python 3.12+.

This replaces #6 with a dedicated branch so the fork can move its default branch from `master` to `main` without adding unrelated fork-governance changes to the upstream PR.